### PR TITLE
 ransack delete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,6 @@ gem 'font-awesome-sass', '~> 5.13'
 
 gem 'kaminari','~> 1.2.1'
 
-gem 'ransack'
-
 gem 'rubocop'
 gem 'rubocop-rails'
 


### PR DESCRIPTION
検索機能gem ransackを使用しなかったため、削除しました。